### PR TITLE
Listen 'onloadend' event before 'readAsDataURL'

### DIFF
--- a/dist/blob-to-base64.es.js
+++ b/dist/blob-to-base64.es.js
@@ -10,11 +10,12 @@ function blobToBase64 (blob, cb) {
   }
 
   var reader = new window.FileReader();
-  reader.readAsDataURL(blob);
-
+  
   reader.onloadend = function () {
     cb(null, reader.result);
   };
+  
+  reader.readAsDataURL(blob);
 }
 
 export default blobToBase64;


### PR DESCRIPTION
You should listen the `onloadend` event before to call `readAsDataURL `. Otherwise, the data may be load before your code reaches the `onloadend` event.